### PR TITLE
Corrigido o erro de compatibilidade com o RAD Studio 10 Seattle Ver…

### DIFF
--- a/src/Horse.Logger.Manager.pas
+++ b/src/Horse.Logger.Manager.pas
@@ -90,7 +90,7 @@ begin
       LLog.{$IFDEF FPC}Add{$ELSE}AddPair{$ENDIF}('request_content_encoding', THorseLoggerManager.ValidateValue(AReq.RawWebRequest.ContentEncoding));
       LLog.{$IFDEF FPC}Add{$ELSE}AddPair{$ENDIF}('request_content_type', THorseLoggerManager.ValidateValue(AReq.RawWebRequest.ContentType));
       LLog.{$IFDEF FPC}Add{$ELSE}AddPair{$ENDIF}('request_content_length', THorseLoggerManager.ValidateValue(AReq.RawWebRequest.ContentLength.ToString));
-      LLog.{$IFDEF FPC}Add{$ELSE}AddPair{$ENDIF}('request_content', THorseLoggerManager.ValidateValue({$IF DEFINED(FPC)} TEncoding.ANSI.GetBytes({$ENDIF}AReq.RawWebRequest.{$IF DEFINED(FPC)}Content){$ELSE}RawContent{$ENDIF}, ''));
+      LLog.{$IFDEF FPC}Add{$ELSE}AddPair{$ENDIF}('request_content', THorseLoggerManager.ValidateValue({$IF DEFINED(FPC)} TEncoding.ANSI.GetBytes({$ENDIF}AReq.RawWebRequest.{$IF DEFINED(FPC)}Content){$ELSE}RawContent{$ENDIF}));
       LLog.{$IFDEF FPC}Add{$ELSE}AddPair{$ENDIF}('response_server', THorseLoggerManager.ValidateValue(ARes.RawWebResponse.Server));
       LLog.{$IFDEF FPC}Add{$ELSE}AddPair{$ENDIF}('response_allow', THorseLoggerManager.ValidateValue(ARes.RawWebResponse.Allow));
       LLog.{$IFDEF FPC}Add{$ELSE}AddPair{$ENDIF}('response_location', THorseLoggerManager.ValidateValue(ARes.RawWebResponse.Location));


### PR DESCRIPTION
Corrigido o erro de compatibilidade com o RAD Studio 10 Seattle Version 23.0.22248.5795 o excesso de parâmetro ao adicionar o 'request_content' no log.

Após analise, validando com o Delphi 11 Community Edition, vi que o erro ocorre na versão 10 Seattle por causa do Web.HTTPApp.TWebRequest.RawContent retornar AnsiString enquanto nos outros retorna TBytes. Como o erro é ocasionado pelo excesso do parâmetro ASeparator, que tem o default igual ao informado, resolvi removê-lo!

Close #15 