### PR TITLE
feat: complete test suite and core manager/thread resilience updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,5 @@ src/*.~*
 *.stat
 *.bak
 *.ppu
+*.log
+*.or

--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,4 @@ src/*.~*
 *.a
 *.stat
 *.bak
+*.ppu

--- a/README.md
+++ b/README.md
@@ -26,8 +26,32 @@ This middleware is compatible with projects developed in:
 |  [console](https://github.com/HashLoad/horse-logger-provider-console) | &nbsp;&nbsp;&nbsp;✔️ | &nbsp;&nbsp;&nbsp;&nbsp;✔️ |
 |  [file](https://github.com/HashLoad/horse-logger-provider-logfile)    | &nbsp;&nbsp;&nbsp;✔️ | &nbsp;&nbsp;&nbsp;&nbsp;✔️ |
 
-## ⚡️ Quickstart
-Examples are provided within each provider.
+## ⚡️ Quickstart & Samples
+We provide a complete, real-life sample project showing how to integrate `horse-logger` with a custom text file log provider and handle exceptions globally. You can find it in the [`samples/`](samples/console/ConsoleSample.dpr) folder.
+
+### Registering custom providers and handling logging errors:
+```delphi
+uses
+  Horse,
+  Horse.Logger.Manager,
+  Horse.Logger.Provider.Contract;
+
+begin
+  // Set global handler for logging errors (optional but recommended)
+  THorseLoggerManager.OnError := procedure(const AProvider: IHorseLoggerProvider; const AException: Exception)
+    begin
+      Writeln('Log Provider ' + AProvider.ClassName + ' failed: ' + AException.Message);
+    end;
+
+  // Register your custom providers
+  THorseLoggerManager.RegisterProvider(TMyCustomLogProvider.Create);
+
+  // Enable middleware
+  THorse.Use(THorseLoggerManager.HorseCallback);
+
+  THorse.Listen(9000);
+end.
+```
 
 ## ⚠️ License
 `horse-logger` is free and open-source middleware licensed under the [MIT License](https://github.com/HashLoad/horse-logger/blob/master/LICENSE). 

--- a/samples/console/ConsoleSample.dpr
+++ b/samples/console/ConsoleSample.dpr
@@ -3,15 +3,29 @@ program ConsoleSample;
 {$APPTYPE CONSOLE}
 
 uses
+  {$IFDEF FPC}
+    {$IFDEF UNIX}
+    cthreads,
+    {$ENDIF}
+  SysUtils, Classes, fpjson,
+  {$ELSE}
   System.SysUtils,
   System.Classes,
   System.JSON,
+  {$ENDIF}
   Horse,
   Horse.Logger.Manager,
   Horse.Logger.Provider.Contract,
   Horse.Logger.Types;
 
 type
+  {$IFDEF FPC}
+  TErrorHandler = class
+  public
+    procedure OnLoggerError(const AProvider: IHorseLoggerProvider; const AException: Exception);
+  end;
+  {$ENDIF}
+
   { TTextFileLogProvider }
   // Exemplo de provedor customizado que grava requisições de forma estruturada em arquivo local
   TTextFileLogProvider = class(TInterfacedObject, IHorseLoggerProvider)
@@ -45,12 +59,21 @@ begin
     for LItem in ALogCache do
     begin
       LLogLine := Format('[%s] %s %s - Status: %s - IP: %s - ExecTime: %sms', [
+        {$IFDEF FPC}
+        LItem.Strings['time_short'],
+        LItem.Strings['request_method'],
+        LItem.Strings['request_path_info'],
+        LItem.Strings['response_status'],
+        LItem.Strings['request_clientip'],
+        LItem.Strings['execution_time']
+        {$ELSE}
         LItem.GetValue<string>('time_short'),
         LItem.GetValue<string>('request_method'),
         LItem.GetValue<string>('request_path_info'),
         LItem.GetValue<string>('response_status'),
         LItem.GetValue<string>('request_clientip'),
         LItem.GetValue<string>('execution_time')
+        {$ENDIF}
       ]);
       Writeln(LTextFile, LLogLine);
     end;
@@ -58,6 +81,13 @@ begin
     CloseFile(LTextFile);
   end;
 end;
+
+{$IFDEF FPC}
+procedure TErrorHandler.OnLoggerError(const AProvider: IHorseLoggerProvider; const AException: Exception);
+begin
+  Writeln('[ERROR CALLBACK] Ocorreu uma falha no provedor de log: ' + AException.Message);
+end;
+{$ENDIF}
 
 { Rotas HTTP }
 
@@ -82,13 +112,24 @@ begin
   raise Exception.Create('Erro interno intencional demonstrativo.');
 end;
 
+var
+  {$IFDEF FPC}
+  LErrHandler: TErrorHandler;
+  {$ENDIF}
 begin
+  {$IFDEF FPC}
+  LErrHandler := TErrorHandler.Create;
+  {$ENDIF}
   try
     // 1. Configura tratamento e reporte de erro customizado do logger
+    {$IFDEF FPC}
+    THorseLoggerManager.OnError := LErrHandler.OnLoggerError;
+    {$ELSE}
     THorseLoggerManager.OnError := procedure(const AProvider: IHorseLoggerProvider; const AException: Exception)
       begin
         Writeln('[ERROR CALLBACK] Ocorreu uma falha no provedor de log: ' + AException.Message);
       end;
+    {$ENDIF}
 
     // 2. Registra o nosso provedor de log em arquivo de texto
     THorseLoggerManager.RegisterProvider(TTextFileLogProvider.Create('app.log'));
@@ -115,4 +156,7 @@ begin
     on E: Exception do
       Writeln(E.ClassName, ': ', E.Message);
   end;
+  {$IFDEF FPC}
+  LErrHandler.Free;
+  {$ENDIF}
 end.

--- a/samples/console/ConsoleSample.dpr
+++ b/samples/console/ConsoleSample.dpr
@@ -1,0 +1,118 @@
+program ConsoleSample;
+
+{$APPTYPE CONSOLE}
+
+uses
+  System.SysUtils,
+  System.Classes,
+  System.JSON,
+  Horse,
+  Horse.Logger.Manager,
+  Horse.Logger.Provider.Contract,
+  Horse.Logger.Types;
+
+type
+  { TTextFileLogProvider }
+  // Exemplo de provedor customizado que grava requisições de forma estruturada em arquivo local
+  TTextFileLogProvider = class(TInterfacedObject, IHorseLoggerProvider)
+  private
+    FFileName: string;
+  public
+    constructor Create(const AFileName: string);
+    procedure DoReceiveLogCache(ALogCache: THorseLoggerCache);
+  end;
+
+{ TTextFileLogProvider }
+
+constructor TTextFileLogProvider.Create(const AFileName: string);
+begin
+  FFileName := AFileName;
+end;
+
+procedure TTextFileLogProvider.DoReceiveLogCache(ALogCache: THorseLoggerCache);
+var
+  LItem: TJSONObject;
+  LTextFile: TextFile;
+  LLogLine: string;
+begin
+  AssignFile(LTextFile, FFileName);
+  try
+    if FileExists(FFileName) then
+      Append(LTextFile)
+    else
+      Rewrite(LTextFile);
+
+    for LItem in ALogCache do
+    begin
+      LLogLine := Format('[%s] %s %s - Status: %s - IP: %s - ExecTime: %sms', [
+        LItem.GetValue<string>('time_short'),
+        LItem.GetValue<string>('request_method'),
+        LItem.GetValue<string>('request_path_info'),
+        LItem.GetValue<string>('response_status'),
+        LItem.GetValue<string>('request_clientip'),
+        LItem.GetValue<string>('execution_time')
+      ]);
+      Writeln(LTextFile, LLogLine);
+    end;
+  finally
+    CloseFile(LTextFile);
+  end;
+end;
+
+{ Rotas HTTP }
+
+procedure PingRoute(Req: THorseRequest; Res: THorseResponse; Next: TNextProc);
+begin
+  Res.Send('pong');
+end;
+
+procedure EchoRoute(Req: THorseRequest; Res: THorseResponse; Next: TNextProc);
+var
+  LBody: string;
+begin
+  LBody := Req.Body;
+  if LBody <> '' then
+    Res.Send(LBody).ContentType('application/json')
+  else
+    Res.Send('no body').Status(THTTPStatus.BadRequest);
+end;
+
+procedure ErrorRoute(Req: THorseRequest; Res: THorseResponse; Next: TNextProc);
+begin
+  raise Exception.Create('Erro interno intencional demonstrativo.');
+end;
+
+begin
+  try
+    // 1. Configura tratamento e reporte de erro customizado do logger
+    THorseLoggerManager.OnError := procedure(const AProvider: IHorseLoggerProvider; const AException: Exception)
+      begin
+        Writeln('[ERROR CALLBACK] Ocorreu uma falha no provedor de log: ' + AException.Message);
+      end;
+
+    // 2. Registra o nosso provedor de log em arquivo de texto
+    THorseLoggerManager.RegisterProvider(TTextFileLogProvider.Create('app.log'));
+
+    // 3. Ativa o middleware global de logs do Horse
+    THorse.Use(THorseLoggerManager.HorseCallback);
+
+    // 4. Mapeia rotas de teste real utilizando procedures estáticas nomeadas
+    THorse.Get('/ping', PingRoute);
+    THorse.Post('/echo', EchoRoute);
+    THorse.Get('/error', ErrorRoute);
+
+    // 5. Inicializa o servidor Horse
+    Writeln('Servidor de Exemplo ativo na porta 9000.');
+    Writeln('Links para testes:');
+    Writeln('  - GET  http://localhost:9000/ping');
+    Writeln('  - POST http://localhost:9000/echo (envie JSON no corpo)');
+    Writeln('  - GET  http://localhost:9000/error (simula erro 500)');
+    Writeln('Pressione Ctrl+C para encerrar o servidor.');
+    Writeln('---');
+
+    THorse.Listen(9000);
+  except
+    on E: Exception do
+      Writeln(E.ClassName, ': ', E.Message);
+  end;
+end.

--- a/samples/console/Dockerfile
+++ b/samples/console/Dockerfile
@@ -1,0 +1,22 @@
+FROM debian:stable-slim
+
+# Instala o compilador do Free Pascal (fpc) e ferramentas necessárias
+RUN apt-get update && apt-get install -y \
+    fpc \
+    curl \
+    && rm -rf /var/lib/apt/lists/*
+
+# Define diretório de trabalho
+WORKDIR /app
+
+# Copia o código-fonte completo
+COPY . .
+
+# Compila o exemplo utilizando o fpc do Linux
+RUN fpc -Mdelphi -Sh -O2 -FE/app/samples/console -Fu"/app/src;/app/modules/horse/src;/app/modules/horse-utils-clientip/src" /app/samples/console/ConsoleSample.dpr
+
+# Expõe a porta 9000
+EXPOSE 9000
+
+# Executa o servidor de exemplo
+CMD ["/app/samples/console/ConsoleSample"]

--- a/src/Horse.Logger.Manager.pas
+++ b/src/Horse.Logger.Manager.pas
@@ -15,7 +15,11 @@ uses
   Horse.Logger.Types, Horse.Logger.Provider.Contract, Horse, Horse.Logger.Thread;
 
 type
+  {$IFDEF FPC}
+  THorseLoggerErrorCallback = procedure(const AProvider: IHorseLoggerProvider; const AException: Exception) of object;
+  {$ELSE}
   THorseLoggerErrorCallback = reference to procedure(const AProvider: IHorseLoggerProvider; const AException: Exception);
+  {$ENDIF}
 
   THorseLoggerManager = class;
   THorseLoggerManagerClass = class of THorseLoggerManager;
@@ -25,6 +29,8 @@ type
     class var FProviderList: TList<IHorseLoggerProvider>;
     class var FDefaultManager: THorseLoggerManager;
     class var FOnError: THorseLoggerErrorCallback;
+    class function GetMaxCacheSize: Integer; static;
+    class procedure SetMaxCacheSize(const AValue: Integer); static;
   protected
     procedure DispatchLogCache; override;
     class function GetProviderList: TList<IHorseLoggerProvider>;
@@ -41,6 +47,7 @@ type
     class function RegisterProvider(const AProvider: IHorseLoggerProvider): THorseLoggerManagerClass;
     class property DefaultManager: THorseLoggerManager read GetDefaultManager;
     class property OnError: THorseLoggerErrorCallback read FOnError write FOnError;
+    class property MaxCacheSize: Integer read GetMaxCacheSize write SetMaxCacheSize;
     class destructor UnInitialize;
   end;
 
@@ -49,6 +56,9 @@ implementation
 uses
 {$IFDEF FPC }
   DateUtils, HTTPDefs,
+  {$IFDEF MSWINDOWS}
+  Windows,
+  {$ENDIF}
 {$ELSE}
   Web.HTTPApp, System.DateUtils,
   {$IFDEF MSWINDOWS}
@@ -185,6 +195,16 @@ begin
   finally
     LLogCache.Free;
   end;
+end;
+
+class function THorseLoggerManager.GetMaxCacheSize: Integer;
+begin
+  Result := GetDefaultManager.FMaxCacheSize;
+end;
+
+class procedure THorseLoggerManager.SetMaxCacheSize(const AValue: Integer);
+begin
+  GetDefaultManager.FMaxCacheSize := AValue;
 end;
 
 class function THorseLoggerManager.GetDefaultManager: THorseLoggerManager;

--- a/src/Horse.Logger.Manager.pas
+++ b/src/Horse.Logger.Manager.pas
@@ -15,6 +15,8 @@ uses
   Horse.Logger.Types, Horse.Logger.Provider.Contract, Horse, Horse.Logger.Thread;
 
 type
+  THorseLoggerErrorCallback = reference to procedure(const AProvider: IHorseLoggerProvider; const AException: Exception);
+
   THorseLoggerManager = class;
   THorseLoggerManagerClass = class of THorseLoggerManager;
 
@@ -22,6 +24,7 @@ type
   private
     class var FProviderList: TList<IHorseLoggerProvider>;
     class var FDefaultManager: THorseLoggerManager;
+    class var FOnError: THorseLoggerErrorCallback;
   protected
     procedure DispatchLogCache; override;
     class function GetProviderList: TList<IHorseLoggerProvider>;
@@ -32,10 +35,12 @@ type
     class function ValidateValue(const AValue: TBytes; const ASeparator: string = ''): THorseLoggerLogItemString; overload;
   	class function ValidateValue(const AValue: TDateTime; const AShort: Boolean): THorseLoggerLogItemString; overload;
     class function GetDefaultManager: THorseLoggerManager; static;
+    class procedure LogError(const AMsg: string);
   public
     class function HorseCallback: THorseCallback; overload;
     class function RegisterProvider(const AProvider: IHorseLoggerProvider): THorseLoggerManagerClass;
     class property DefaultManager: THorseLoggerManager read GetDefaultManager;
+    class property OnError: THorseLoggerErrorCallback read FOnError write FOnError;
     class destructor UnInitialize;
   end;
 
@@ -46,6 +51,9 @@ uses
   DateUtils, HTTPDefs,
 {$ELSE}
   Web.HTTPApp, System.DateUtils,
+  {$IFDEF MSWINDOWS}
+  Winapi.Windows,
+  {$ENDIF}
 {$ENDIF}
   Horse.Utils.ClientIP;
 
@@ -57,8 +65,10 @@ var
   LBeforeDateTime: TDateTime;
   LAfterDateTime: TDateTime;
   LMilliSecondsBetween: Integer;
+  LRequestContent: THorseLoggerLogItemString;
 begin
   LBeforeDateTime := Now();
+  LRequestContent := THorseLoggerManager.ValidateValue({$IF DEFINED(FPC)} TEncoding.ANSI.GetBytes({$ENDIF}AReq.RawWebRequest.{$IF DEFINED(FPC)}Content){$ELSE}RawContent{$ENDIF});
   try
     ANext();
   finally
@@ -91,7 +101,7 @@ begin
       LLog.{$IFDEF FPC}Add{$ELSE}AddPair{$ENDIF}('request_content_encoding', THorseLoggerManager.ValidateValue(AReq.RawWebRequest.ContentEncoding));
       LLog.{$IFDEF FPC}Add{$ELSE}AddPair{$ENDIF}('request_content_type', THorseLoggerManager.ValidateValue(AReq.RawWebRequest.ContentType));
       LLog.{$IFDEF FPC}Add{$ELSE}AddPair{$ENDIF}('request_content_length', THorseLoggerManager.ValidateValue(AReq.RawWebRequest.ContentLength.ToString));
-      LLog.{$IFDEF FPC}Add{$ELSE}AddPair{$ENDIF}('request_content', THorseLoggerManager.ValidateValue({$IF DEFINED(FPC)} TEncoding.ANSI.GetBytes({$ENDIF}AReq.RawWebRequest.{$IF DEFINED(FPC)}Content){$ELSE}RawContent{$ENDIF}));
+      LLog.{$IFDEF FPC}Add{$ELSE}AddPair{$ENDIF}('request_content', LRequestContent);
       LLog.{$IFDEF FPC}Add{$ELSE}AddPair{$ENDIF}('response_server', THorseLoggerManager.ValidateValue(ARes.RawWebResponse.Server));
       LLog.{$IFDEF FPC}Add{$ELSE}AddPair{$ENDIF}('response_allow', THorseLoggerManager.ValidateValue(ARes.RawWebResponse.Allow));
       LLog.{$IFDEF FPC}Add{$ELSE}AddPair{$ENDIF}('response_location', THorseLoggerManager.ValidateValue(ARes.RawWebResponse.Location));
@@ -111,8 +121,10 @@ begin
         LLog.AddPair('response_title', THorseLoggerManager.ValidateValue(ARes.RawWebResponse.Title));
         LLog.AddPair('response_content_version', THorseLoggerManager.ValidateValue(ARes.RawWebResponse.ContentVersion));
       {$ENDIF}
-    finally
       THorseLoggerManager.GetDefaultManager.NewLog(LLog);
+    except
+      LRequestContent.Free;
+      LLog.Free;
     end;
   end;
 end;
@@ -126,6 +138,20 @@ begin
     Result := Result + ASeparator + IntToHex(AValue[LIndex], 2);
 end;
 
+class procedure THorseLoggerManager.LogError(const AMsg: string);
+begin
+  {$IFDEF MSWINDOWS}
+  OutputDebugString(PChar(AMsg));
+  {$ENDIF}
+  if System.IsConsole then
+  begin
+    try
+      System.Writeln(System.ErrOutput, AMsg);
+    except
+    end;
+  end;
+end;
+
 procedure THorseLoggerManager.DispatchLogCache;
 var
   LLogCache: THorseLoggerCache;
@@ -136,8 +162,25 @@ begin
   try
     for I := 0 to Pred(GetProviderList.Count) do
     begin
-      if Supports(GetProviderList.Items[I], IHorseLoggerProvider, LHorseLoggerProvider)  then
-        LHorseLoggerProvider.DoReceiveLogCache(LLogCache);
+      try
+        if Supports(GetProviderList.Items[I], IHorseLoggerProvider, LHorseLoggerProvider)  then
+          LHorseLoggerProvider.DoReceiveLogCache(LLogCache);
+      except
+        on E: Exception do
+        begin
+          if Assigned(FOnError) then
+          begin
+            try
+              FOnError(GetProviderList.Items[I], E);
+            except
+              on E2: Exception do
+                LogError('[Horse.Logger] Erro interno no callback OnError: ' + E2.Message);
+            end;
+          end
+          else
+            LogError('[Horse.Logger] Erro no provedor: ' + E.Message);
+        end;
+      end;
     end;
   finally
     LLogCache.Free;
@@ -175,16 +218,17 @@ end;
 
 class destructor THorseLoggerManager.UnInitialize;
 begin
-  if FProviderList <> nil then
-  begin
-    FProviderList.Free;
-  end;
   if FDefaultManager <> nil then
   begin
     FDefaultManager.Terminate;
     FDefaultManager.GetEvent.SetEvent;
     FDefaultManager.WaitFor;
     FDefaultManager.Free;
+  end;
+  if FProviderList <> nil then
+  begin
+    FProviderList.Free;
+    FProviderList := nil;
   end;
 end;
 

--- a/src/Horse.Logger.Manager.pas
+++ b/src/Horse.Logger.Manager.pas
@@ -29,11 +29,11 @@ type
     procedure DispatchLogCache; override;
     class function GetProviderList: TList<IHorseLoggerProvider>;
     class function ByteArrayToHexString(const AValue: TBytes; const ASeparator: string = ''): string;
-    class function ValidateValue(const AValue: Integer): THorseLoggerLogItemNumber; overload;
-    class function ValidateValue(const AValue: string): THorseLoggerLogItemString; overload;
-    class function ValidateValue(const AValue: string; const AContentType: string): THorseLoggerLogItemString; overload;
-    class function ValidateValue(const AValue: TBytes; const ASeparator: string = ''): THorseLoggerLogItemString; overload;
-  	class function ValidateValue(const AValue: TDateTime; const AShort: Boolean): THorseLoggerLogItemString; overload;
+    class function ValidateValue(const AValue: Integer): {$IF DEFINED(FPC)}TJSONData{$ELSE}TJSONValue{$ENDIF}; overload;
+    class function ValidateValue(const AValue: string): {$IF DEFINED(FPC)}TJSONData{$ELSE}TJSONValue{$ENDIF}; overload;
+    class function ValidateValue(const AValue: string; const AContentType: string): {$IF DEFINED(FPC)}TJSONData{$ELSE}TJSONValue{$ENDIF}; overload;
+    class function ValidateValue(const AValue: TBytes; const ASeparator: string = ''): {$IF DEFINED(FPC)}TJSONData{$ELSE}TJSONValue{$ENDIF}; overload;
+  	class function ValidateValue(const AValue: TDateTime; const AShort: Boolean): {$IF DEFINED(FPC)}TJSONData{$ELSE}TJSONValue{$ENDIF}; overload;
     class function GetDefaultManager: THorseLoggerManager; static;
     class procedure LogError(const AMsg: string);
   public
@@ -65,7 +65,7 @@ var
   LBeforeDateTime: TDateTime;
   LAfterDateTime: TDateTime;
   LMilliSecondsBetween: Integer;
-  LRequestContent: THorseLoggerLogItemString;
+  LRequestContent: {$IF DEFINED(FPC)}TJSONData{$ELSE}TJSONValue{$ENDIF};
 begin
   LBeforeDateTime := Now();
   LRequestContent := THorseLoggerManager.ValidateValue({$IF DEFINED(FPC)} TEncoding.ANSI.GetBytes({$ENDIF}AReq.RawWebRequest.{$IF DEFINED(FPC)}Content){$ELSE}RawContent{$ENDIF});
@@ -232,48 +232,43 @@ begin
   end;
 end;
 
-class function THorseLoggerManager.ValidateValue(const AValue: TBytes; const ASeparator: string = ''): THorseLoggerLogItemString;
+class function THorseLoggerManager.ValidateValue(const AValue: TBytes; const ASeparator: string = ''): {$IF DEFINED(FPC)}TJSONData{$ELSE}TJSONValue{$ENDIF};
 begin
   Result := THorseLoggerLogItemString.Create(ByteArrayToHexString(AValue, ASeparator));
 end;
 
-class function THorseLoggerManager.ValidateValue(const AValue: Integer): THorseLoggerLogItemNumber;
+class function THorseLoggerManager.ValidateValue(const AValue: Integer): {$IF DEFINED(FPC)}TJSONData{$ELSE}TJSONValue{$ENDIF};
 begin
   Result := THorseLoggerLogItemNumber.Create(AValue);
 end;
 
-class function THorseLoggerManager.ValidateValue(const AValue: string): THorseLoggerLogItemString;
+class function THorseLoggerManager.ValidateValue(const AValue: string): {$IF DEFINED(FPC)}TJSONData{$ELSE}TJSONValue{$ENDIF};
 begin
   Result := THorseLoggerLogItemString.Create(AValue);
 end;
 
-class function THorseLoggerManager.ValidateValue(const AValue: TDateTime; const AShort: Boolean): THorseLoggerLogItemString;
+class function THorseLoggerManager.ValidateValue(const AValue: TDateTime; const AShort: Boolean): {$IF DEFINED(FPC)}TJSONData{$ELSE}TJSONValue{$ENDIF};
 begin
   if AShort then
-  	Result := THorseLoggerLogItemString.Create(FormatDateTime('dd/mm/yyyy hh:mm:ss.zzz', AValue))
+  	Result := THorseLoggerLogItemString.Create(FormatDateTime('dd/MM/yyyy hh:mm:ss.zzz', AValue))
   else
     Result := THorseLoggerLogItemString.Create(FormatDateTime('dd/MMMM/yyyy hh:mm:ss.zzz', AValue));
 end;
 
-class function THorseLoggerManager.ValidateValue(const AValue: string; const AContentType: string): THorseLoggerLogItemString;
+class function THorseLoggerManager.ValidateValue(const AValue: string; const AContentType: string): {$IF DEFINED(FPC)}TJSONData{$ELSE}TJSONValue{$ENDIF};
 var
   LJSON: {$IF DEFINED(FPC)}TJsonData{$ELSE}TJSONValue{$ENDIF};
 begin
   if ((AValue <> '') and (Pos('application/json', AContentType) > 0)) then
   begin
-    LJSON := nil;
     try
-      try
-        LJSON := {$IF DEFINED(FPC)} GetJSON(AValue) {$ELSE} TJSONObject.ParseJSONValue(AValue) {$ENDIF};
-        if Assigned(LJSON) then
-          Result := THorseLoggerLogItemString.Create(LJSON.ToString)
-        else
-          Result := THorseLoggerLogItemString.Create(AValue);
-      except
+      LJSON := {$IF DEFINED(FPC)} GetJSON(AValue) {$ELSE} TJSONObject.ParseJSONValue(AValue) {$ENDIF};
+      if Assigned(LJSON) then
+        Result := LJSON
+      else
         Result := THorseLoggerLogItemString.Create(AValue);
-      end;
-    finally
-      LJSON.Free;
+    except
+      Result := THorseLoggerLogItemString.Create(AValue);
     end;
   end
   else

--- a/src/Horse.Logger.Thread.pas
+++ b/src/Horse.Logger.Thread.pas
@@ -29,6 +29,7 @@ type
 
   protected
     { protected declarations }
+    FMaxCacheSize: Integer;
     function GetLogCache: THorseLoggerCache;
 
     function GetCriticalSection: TCriticalSection;
@@ -55,6 +56,7 @@ begin
   FEvent := TEvent.Create{$IFDEF FPC}(nil, False, True, TGuid.NewGuid.ToString(True)){$ENDIF};
   FCriticalSection := TCriticalSection.Create;
   FLogCache := THorseLoggerCache.Create;
+  FMaxCacheSize := 0;
 end;
 
 procedure THorseLoggerThread.BeforeDestruction;
@@ -80,7 +82,6 @@ begin
   while not(Self.Terminated) do
   begin
     LWait := GetEvent.WaitFor(INFINITE);
-    GetEvent.ResetEvent;
     case LWait of
       wrSignaled:
         begin
@@ -130,6 +131,20 @@ end;
 function THorseLoggerThread.NewLog(ALog: THorseLoggerLog): THorseLoggerThread;
 begin
   Result := Self;
+  if FMaxCacheSize > 0 then
+  begin
+    GetCriticalSection.Enter;
+    try
+      if GetLogCache.Count >= FMaxCacheSize then
+      begin
+        ALog.Free;
+        Exit;
+      end;
+    finally
+      GetCriticalSection.Leave;
+    end;
+  end;
+
   GetCriticalSection.Enter;
   try
     GetLogCache.Add(ALog);

--- a/src/Horse.Logger.Thread.pas
+++ b/src/Horse.Logger.Thread.pas
@@ -90,6 +90,7 @@ begin
       Continue;
     end;
   end;
+  DispatchLogCache;
 end;
 
 function THorseLoggerThread.ExtractLogCache: THorseLoggerCache;

--- a/src/Horse.Logger.Thread.pas
+++ b/src/Horse.Logger.Thread.pas
@@ -95,27 +95,20 @@ end;
 
 function THorseLoggerThread.ExtractLogCache: THorseLoggerCache;
 var
-  LLogCache: THorseLoggerCache;
+  LTempCache: THorseLoggerCache;
 begin
-  GetCriticalSection.Enter;
+  LTempCache := THorseLoggerCache.Create(True);
   try
-    LLogCache := THorseLoggerCache.Create;
-    while GetLogCache.Count > 0 do
-      LLogCache.Add(
-      {$IFDEF FPC }
-        GetLogCache.ExtractIndex(0)
-      {$ELSE}
-        {$IFDEF CompilerVersion >= 33.0}
-        GetLogCache.ExtractAt(0)
-        {$ELSE}
-        GetLogCache.Extract(GetLogCache.Items[0])
-        {$ENDIF}
-      {$ENDIF}
-      );
-    Result := LLogCache;
-    ResetLogCache;
-  finally
-    GetCriticalSection.Leave;
+    GetCriticalSection.Enter;
+    try
+      Result := FLogCache;
+      FLogCache := LTempCache;
+    finally
+      GetCriticalSection.Leave;
+    end;
+  except
+    LTempCache.Free;
+    raise;
   end;
 end;
 

--- a/src/Horse.Logger.Utils.pas
+++ b/src/Horse.Logger.Utils.pas
@@ -35,14 +35,18 @@ const
 
 class function THorseLoggerUtils.GetFormatParams(AFormat: string): StringArray;
 var
-  LRegex: {$IFDEF FPC}TRegExpr{$ELSE}TRegEx{$ENDIF};
+  LRegex: TRegExpr;
+  LCount: Integer;
 begin
   LRegex := TRegExpr.Create(REGEXP_PARAM);
   try
+    LCount := 0;
     if LRegex.Exec(AFormat) then
     begin
       repeat
-        Result := Result + [LRegex.Match[0].Substring(2, LRegex.Match[0].Length - 3)];
+        Inc(LCount);
+        SetLength(Result, LCount);
+        Result[LCount - 1] := LRegex.Match[0].Substring(2, LRegex.Match[0].Length - 3);
       until not LRegex.ExecNext;
     end;
   finally
@@ -54,12 +58,11 @@ end;
 
 class function THorseLoggerUtils.GetFormatParams(AFormat: string): StringArray;
 var
-  LRegex: TRegEx;
   LMatches: TMatchCollection;
   LIndex: Integer;
 begin
-  LRegex := TRegEx.Create(REGEXP_PARAM);
-  LMatches := LRegex.Matches(AFormat);
+  // Utiliza a chamada estática TRegEx.Matches que possui cache interno e é Thread-Safe por padrão no Delphi
+  LMatches := TRegEx.Matches(AFormat, REGEXP_PARAM);
 
   SetLength(Result, LMatches.Count);
 

--- a/tests/Horse.Logger.Tests.Integration.pas
+++ b/tests/Horse.Logger.Tests.Integration.pas
@@ -1,0 +1,254 @@
+unit Horse.Logger.Tests.Integration;
+
+interface
+
+uses
+  DUnitX.TestFramework, System.Classes, System.SysUtils, System.JSON,
+  System.Net.HttpClient, System.SyncObjs, Horse, Horse.Logger.Manager,
+  Horse.Logger.Types;
+
+type
+  THorseServerThread = class(TThread)
+  private
+    FPort: Integer;
+  protected
+    procedure Execute; override;
+  public
+    constructor Create(const APort: Integer);
+  end;
+
+  [TestFixture]
+  THorseLoggerIntegrationTests = class
+  private
+    FServerThread: THorseServerThread;
+    FClient: THTTPClient;
+  public
+    [SetupFixture]
+    procedure SetupFixture;
+    [TearDownFixture]
+    procedure TearDownFixture;
+    [Setup]
+    procedure Setup;
+    [TearDown]
+    procedure TearDown;
+
+    [Test]
+    procedure TestGET_ShouldLogRequestAndResponse;
+    [Test]
+    procedure TestPOST_WithJSON_ShouldLogRequestAndResponseContent;
+    [Test]
+    procedure TestGET_WithErrorInRoute_ShouldStillLogRequestAndResponse;
+    [Test]
+    procedure TestLogContractSchema;
+  end;
+
+implementation
+
+uses
+  Horse.Logger.Tests.Manager,
+  Horse.Logger.Provider.Contract;
+
+type
+  THorseLoggerManagerHack = class(THorseLoggerManager);
+
+{ THorseServerThread }
+
+constructor THorseServerThread.Create(const APort: Integer);
+begin
+  inherited Create(False);
+  FPort := APort;
+  FreeOnTerminate := False;
+end;
+
+procedure THorseServerThread.Execute;
+begin
+  THorse.Get('/ping',
+    procedure(Req: THorseRequest; Res: THorseResponse; Next: TNextProc)
+    begin
+      Res.Send('pong');
+    end);
+
+  THorse.Post('/echo',
+    procedure(Req: THorseRequest; Res: THorseResponse; Next: TNextProc)
+    var
+      LBody: TJSONObject;
+      LRawBody: string;
+    begin
+      LRawBody := Req.Body;
+      if LRawBody <> '' then
+      begin
+        LBody := TJSONObject.ParseJSONValue(LRawBody) as TJSONObject;
+        try
+          if Assigned(LBody) then
+            Res.Send(LRawBody).ContentType('application/json')
+          else
+            Res.Send('invalid json').Status(THTTPStatus.BadRequest);
+        finally
+          LBody.Free;
+        end;
+      end
+      else
+        Res.Send('no body').Status(THTTPStatus.BadRequest);
+    end);
+
+  THorse.Get('/error',
+    procedure(Req: THorseRequest; Res: THorseResponse; Next: TNextProc)
+    begin
+      raise Exception.Create('Erro interno intencional de teste');
+    end);
+
+  THorse.Use(THorseLoggerManager.HorseCallback);
+
+  THorse.Listen(FPort);
+end;
+
+{ THorseLoggerIntegrationTests }
+
+procedure THorseLoggerIntegrationTests.SetupFixture;
+begin
+  FServerThread := THorseServerThread.Create(9090);
+  Sleep(200);
+  FClient := THTTPClient.Create;
+  RegistrarProviderSeNecessario;
+end;
+
+procedure THorseLoggerIntegrationTests.TearDownFixture;
+begin
+  FClient.Free;
+  THorse.StopListen;
+  FServerThread.WaitFor;
+  FServerThread.Free;
+end;
+
+procedure THorseLoggerIntegrationTests.Setup;
+begin
+  TTestProvider.ClearReceivedLogs;
+  THorseLoggerManagerHack(THorseLoggerManager.DefaultManager).ResetLogCache;
+  TTestProvider.FEnabled := True;
+end;
+
+procedure THorseLoggerIntegrationTests.TearDown;
+begin
+  Sleep(50);
+  TTestProvider.FEnabled := False;
+  TTestProvider.ClearReceivedLogs;
+end;
+
+procedure THorseLoggerIntegrationTests.TestGET_ShouldLogRequestAndResponse;
+var
+  LResponse: IHTTPResponse;
+  LWaitResult: TWaitResult;
+  LLog: TJSONObject;
+begin
+  LResponse := FClient.Get('http://localhost:9090/ping');
+  Assert.AreEqual(200, LResponse.StatusCode);
+  Assert.AreEqual('pong', LResponse.ContentAsString);
+
+  LWaitResult := TTestProvider.Event.WaitFor(500);
+  Assert.AreEqual(TWaitResult.wrSignaled, LWaitResult, 'O log assíncrono não foi despachado para o provider.');
+  
+  if TTestProvider.ReceivedLogs.Count <> 1 then
+  begin
+    Writeln('--- DEBUG GET: Recebidos ' + IntToStr(TTestProvider.ReceivedLogs.Count) + ' logs ---');
+    for var I := 0 to TTestProvider.ReceivedLogs.Count - 1 do
+      Writeln('LOG ' + IntToStr(I) + ': ' + TTestProvider.ReceivedLogs.Items[I].ToString);
+  end;
+  Assert.AreEqual(1, TTestProvider.ReceivedLogs.Count, 'O provider deveria ter exatamente 1 log.');
+
+  LLog := TTestProvider.ReceivedLogs.Items[0];
+  Assert.AreEqual('GET', LLog.GetValue<string>('request_method'), 'Método HTTP incorreto no log.');
+  Assert.AreEqual('/ping', LLog.GetValue<string>('request_path_info'), 'Path info incorreto no log.');
+  Assert.AreEqual('200', LLog.GetValue<string>('response_status'), 'Status code da resposta incorreto no log.');
+  Assert.AreEqual('pong', LLog.GetValue<string>('response_content'), 'Conteúdo de resposta incorreto no log.');
+end;
+
+procedure THorseLoggerIntegrationTests.TestPOST_WithJSON_ShouldLogRequestAndResponseContent;
+var
+  LResponse: IHTTPResponse;
+  LWaitResult: TWaitResult;
+  LPostData: TStringStream;
+  LLog: TJSONObject;
+begin
+  LPostData := TStringStream.Create('{"input":"hello"}', TEncoding.UTF8);
+  try
+    FClient.ContentType := 'application/json';
+    LResponse := FClient.Post('http://localhost:9090/echo', LPostData);
+    Assert.AreEqual(200, LResponse.StatusCode);
+    Assert.IsTrue(LResponse.ContentAsString.Contains('"input"'), 'Resposta HTTP nao contem "input". Recebido: ' + LResponse.ContentAsString);
+    Assert.IsTrue(LResponse.ContentAsString.Contains('"hello"'), 'Resposta HTTP nao contem "hello". Recebido: ' + LResponse.ContentAsString);
+  finally
+    LPostData.Free;
+  end;
+
+  LWaitResult := TTestProvider.Event.WaitFor(500);
+  Assert.AreEqual(TWaitResult.wrSignaled, LWaitResult, 'O log assíncrono não foi despachado para o provider.');
+  Assert.AreEqual(1, TTestProvider.ReceivedLogs.Count, 'O provider deveria ter exatamente 1 log.');
+
+  LLog := TTestProvider.ReceivedLogs.Items[0];
+  Writeln('--- DEBUG POST LOG: ' + LLog.ToString);
+  
+  Assert.AreEqual('POST', LLog.GetValue<string>('request_method'), 'Método HTTP incorreto no log.');
+  Assert.AreEqual('/echo', LLog.GetValue<string>('request_path_info'), 'Path info incorreto no log.');
+  Assert.AreEqual('200', LLog.GetValue<string>('response_status'), 'Status code da resposta incorreto no log.');
+  
+  Assert.AreEqual('7b22696e707574223a2268656c6c6f227d', LLog.GetValue<string>('request_content').ToLower, 'Corpo da requisicao incorreto no log. LOG: ' + LLog.ToString);
+  Assert.IsTrue(LLog.GetValue<string>('response_content').Contains('"input"'), 'Corpo da resposta incorreto no log. LOG: ' + LLog.ToString);
+end;
+
+procedure THorseLoggerIntegrationTests.TestGET_WithErrorInRoute_ShouldStillLogRequestAndResponse;
+var
+  LResponse: IHTTPResponse;
+  LWaitResult: TWaitResult;
+  LLog: TJSONObject;
+begin
+  try
+    LResponse := FClient.Get('http://localhost:9090/error');
+  except
+  end;
+
+  Assert.AreEqual(500, LResponse.StatusCode);
+
+  LWaitResult := TTestProvider.Event.WaitFor(500);
+  Assert.AreEqual(TWaitResult.wrSignaled, LWaitResult, 'O log do erro HTTP nao foi despachado.');
+  Assert.AreEqual(1, TTestProvider.ReceivedLogs.Count, 'O provider deveria ter recebido exatamente 1 log.');
+
+  LLog := TTestProvider.ReceivedLogs.Items[0];
+  Assert.AreEqual('GET', LLog.GetValue<string>('request_method'), 'Metodo HTTP incorreto no log.');
+  Assert.AreEqual('/error', LLog.GetValue<string>('request_path_info'), 'Path info incorreto no log.');
+  Assert.AreEqual('500', LLog.GetValue<string>('response_status'), 'Status code 500 incorreto no log.');
+end;
+
+procedure THorseLoggerIntegrationTests.TestLogContractSchema;
+var
+  LResponse: IHTTPResponse;
+  LWaitResult: TWaitResult;
+  LLog: TJSONObject;
+  LRequiredFields: TArray<string>;
+  LField: string;
+begin
+  LResponse := FClient.Get('http://localhost:9090/ping');
+  Assert.AreEqual(200, LResponse.StatusCode);
+
+  LWaitResult := TTestProvider.Event.WaitFor(500);
+  Assert.AreEqual(TWaitResult.wrSignaled, LWaitResult, 'O log de integracao nao foi despachado.');
+  Assert.AreEqual(1, TTestProvider.ReceivedLogs.Count);
+
+  LLog := TTestProvider.ReceivedLogs.Items[0];
+
+  LRequiredFields := TArray<string>.Create(
+    'time', 'time_short', 'execution_time', 'request_clientip', 'request_method',
+    'request_version', 'request_url', 'request_query', 'request_path_info',
+    'request_host', 'request_content_type', 'request_content_length', 'request_content',
+    'response_content_type', 'response_content_length', 'response_content', 'response_status'
+  );
+
+  for LField in LRequiredFields do
+  begin
+    Assert.IsNotNull(LLog.FindValue(LField), 'O campo de contrato obrigatório "' + LField + '" nao foi encontrado no JSON de log.');
+  end;
+end;
+
+initialization
+  TDUnitX.RegisterTestFixture(THorseLoggerIntegrationTests);
+
+end.

--- a/tests/Horse.Logger.Tests.Integration.pas
+++ b/tests/Horse.Logger.Tests.Integration.pas
@@ -192,7 +192,10 @@ begin
   Assert.AreEqual('200', LLog.GetValue<string>('response_status'), 'Status code da resposta incorreto no log.');
   
   Assert.AreEqual('7b22696e707574223a2268656c6c6f227d', LLog.GetValue<string>('request_content').ToLower, 'Corpo da requisicao incorreto no log. LOG: ' + LLog.ToString);
-  Assert.IsTrue(LLog.GetValue<string>('response_content').Contains('"input"'), 'Corpo da resposta incorreto no log. LOG: ' + LLog.ToString);
+  var LResponseContent: TJSONValue := LLog.GetValue('response_content');
+  Assert.IsNotNull(LResponseContent, 'response_content nao encontrado no log');
+  Assert.IsTrue(LResponseContent is TJSONObject, 'response_content deveria ser um TJSONObject estruturado.');
+  Assert.AreEqual('hello', TJSONObject(LResponseContent).GetValue<string>('input'), 'Atributo "input" incorreto no response_content do log.');
 end;
 
 procedure THorseLoggerIntegrationTests.TestGET_WithErrorInRoute_ShouldStillLogRequestAndResponse;

--- a/tests/Horse.Logger.Tests.Manager.pas
+++ b/tests/Horse.Logger.Tests.Manager.pas
@@ -1,0 +1,539 @@
+unit Horse.Logger.Tests.Manager;
+
+interface
+
+uses
+  DUnitX.TestFramework, System.SysUtils, System.JSON, System.SyncObjs, System.DateUtils,
+  System.Classes,
+  Horse.Logger.Types, Horse.Logger.Provider.Contract, Horse.Logger.Manager;
+
+type
+  TTestProvider = class(TInterfacedObject, IHorseLoggerProvider)
+  private
+    class var FReceivedLogs: THorseLoggerCache;
+    class var FEvent: TEvent;
+  public
+    class var FEnabled: Boolean;
+    class var FRegistered: Boolean;
+    class procedure ClearReceivedLogs;
+    class property ReceivedLogs: THorseLoggerCache read FReceivedLogs;
+    class property Event: TEvent read FEvent;
+    procedure DoReceiveLogCache(ALogCache: THorseLoggerCache);
+    class constructor Create;
+    class destructor Destroy;
+  end;
+
+  TExceptionProvider = class(TInterfacedObject, IHorseLoggerProvider)
+  public
+    procedure DoReceiveLogCache(ALogCache: THorseLoggerCache);
+  end;
+
+  TAuxTestProvider = class(TInterfacedObject, IHorseLoggerProvider)
+  private
+    class var FReceivedLogs: THorseLoggerCache;
+    class var FEvent: TEvent;
+  public
+    class var FEnabled: Boolean;
+    class var FRegistered: Boolean;
+    class procedure ClearReceivedLogs;
+    class property ReceivedLogs: THorseLoggerCache read FReceivedLogs;
+    class property Event: TEvent read FEvent;
+    procedure DoReceiveLogCache(ALogCache: THorseLoggerCache);
+    class constructor Create;
+    class destructor Destroy;
+  end;
+
+  [TestFixture]
+  THorseLoggerManagerTests = class
+  private
+    FProvider: IHorseLoggerProvider;
+  public
+    [SetupFixture]
+    procedure SetupFixture;
+    [TearDownFixture]
+    procedure TearDownFixture;
+    [Setup]
+    procedure Setup;
+    [TearDown]
+    procedure TearDown;
+
+    [Test]
+    procedure TestNewLog_ShouldDispatchToProvider;
+    [Test]
+    procedure TestValidateValue_String;
+    [Test]
+    procedure TestValidateValue_Integer;
+    [Test]
+    procedure TestValidateValue_DateTime_Short;
+    [Test]
+    procedure TestValidateValue_DateTime_Long;
+    [Test]
+    procedure TestValidateValue_Bytes_WithoutSeparator;
+    [Test]
+    procedure TestValidateValue_Bytes_WithSeparator;
+    [Test]
+    procedure TestValidateValue_JSON_Valid;
+    [Test]
+    procedure TestValidateValue_JSON_Invalid;
+    [Test]
+    procedure TestValidateValue_JSON_NonJsonContentType;
+    [Test]
+    procedure TestNewLog_WithProviderException_ShouldNotAffectOtherProviders;
+    [Test]
+    procedure TestUnInitialize_WithRemainingLogs_ShouldDispatchBeforeTermination;
+    [Test]
+    procedure TestNewLog_WithMultipleProviders_ShouldDeliverToAll;
+    [Test]
+    procedure TestNewLog_WithExtremeConcurrency_ShouldNotDeadlockOrLoseLogs;
+  end;
+
+  procedure RegistrarProviderSeNecessario;
+
+implementation
+
+type
+  THorseLoggerManagerHack = class(THorseLoggerManager);
+
+{ TTestProvider }
+
+class constructor TTestProvider.Create;
+begin
+  FReceivedLogs := THorseLoggerCache.Create(True);
+  FEvent := TEvent.Create;
+  FEnabled := False;
+  FRegistered := False;
+end;
+
+class destructor TTestProvider.Destroy;
+begin
+  FReceivedLogs.Free;
+  FEvent.Free;
+end;
+
+class procedure TTestProvider.ClearReceivedLogs;
+begin
+  FReceivedLogs.Clear;
+  FEvent.ResetEvent;
+end;
+
+procedure TTestProvider.DoReceiveLogCache(ALogCache: THorseLoggerCache);
+var
+  LItem: TJSONObject;
+begin
+  if not FEnabled then
+    Exit;
+  for LItem in ALogCache do
+  begin
+    FReceivedLogs.Add(TJSONObject(LItem.Clone));
+  end;
+  FEvent.SetEvent;
+end;
+
+{ TAuxTestProvider }
+
+class constructor TAuxTestProvider.Create;
+begin
+  FReceivedLogs := THorseLoggerCache.Create(True);
+  FEvent := TEvent.Create;
+  FEnabled := False;
+  FRegistered := False;
+end;
+
+class destructor TAuxTestProvider.Destroy;
+begin
+  FReceivedLogs.Free;
+  FEvent.Free;
+end;
+
+class procedure TAuxTestProvider.ClearReceivedLogs;
+begin
+  FReceivedLogs.Clear;
+  FEvent.ResetEvent;
+end;
+
+procedure TAuxTestProvider.DoReceiveLogCache(ALogCache: THorseLoggerCache);
+var
+  LItem: TJSONObject;
+begin
+  if not FEnabled then
+    Exit;
+  for LItem in ALogCache do
+  begin
+    FReceivedLogs.Add(TJSONObject(LItem.Clone));
+  end;
+  FEvent.SetEvent;
+end;
+
+procedure RegistrarProviderSeNecessario;
+begin
+  if not TTestProvider.FRegistered then
+  begin
+    THorseLoggerManager.RegisterProvider(TTestProvider.Create);
+    TTestProvider.FRegistered := True;
+  end;
+end;
+
+{ THorseLoggerManagerTests }
+
+procedure THorseLoggerManagerTests.SetupFixture;
+begin
+  RegistrarProviderSeNecessario;
+end;
+
+procedure THorseLoggerManagerTests.TearDownFixture;
+begin
+end;
+
+procedure THorseLoggerManagerTests.Setup;
+begin
+  TTestProvider.ClearReceivedLogs;
+  THorseLoggerManagerHack(THorseLoggerManager.DefaultManager).ResetLogCache;
+  TTestProvider.FEnabled := True;
+end;
+
+procedure THorseLoggerManagerTests.TearDown;
+begin
+  Sleep(50);
+  TTestProvider.FEnabled := False;
+  TTestProvider.ClearReceivedLogs;
+end;
+
+procedure THorseLoggerManagerTests.TestNewLog_ShouldDispatchToProvider;
+var
+  LLog: TJSONObject;
+  LWaitResult: TWaitResult;
+begin
+  LLog := TJSONObject.Create;
+  LLog.AddPair('test_key', 'test_value');
+
+  THorseLoggerManager.DefaultManager.NewLog(LLog);
+
+  // Aguarda até que o provider receba o log de forma assíncrona (máximo 500ms)
+  LWaitResult := TTestProvider.Event.WaitFor(500);
+
+  var LItem: TJSONObject;
+  var LFoundItem: TJSONObject;
+  LFoundItem := nil;
+  for LItem in TTestProvider.ReceivedLogs do
+  begin
+    if LItem.GetValue<string>('test_key') = 'test_value' then
+    begin
+      LFoundItem := LItem;
+      Break;
+    end;
+  end;
+  Assert.IsNotNull(LFoundItem, 'O log de teste enviado nao foi recebido pelo provider.');
+  Assert.AreEqual('test_value', LFoundItem.GetValue<string>('test_key'), 'O valor do log recebido esta incorreto.');
+end;
+
+procedure THorseLoggerManagerTests.TestValidateValue_String;
+var
+  LJSONString: THorseLoggerLogItemString;
+begin
+  LJSONString := THorseLoggerManagerHack.ValidateValue('hello');
+  try
+    Assert.AreEqual('hello', LJSONString.Value);
+  finally
+    LJSONString.Free;
+  end;
+end;
+
+procedure THorseLoggerManagerTests.TestValidateValue_Integer;
+var
+  LJSONNumber: THorseLoggerLogItemNumber;
+begin
+  LJSONNumber := THorseLoggerManagerHack.ValidateValue(42);
+  try
+    Assert.AreEqual('42', LJSONNumber.ToString);
+  finally
+    LJSONNumber.Free;
+  end;
+end;
+
+procedure THorseLoggerManagerTests.TestValidateValue_DateTime_Short;
+var
+  LDateTime: TDateTime;
+  LJSONString: THorseLoggerLogItemString;
+  LExpected: string;
+begin
+  LDateTime := EncodeDateTime(2026, 7, 2, 23, 45, 0, 0);
+  LExpected := FormatDateTime('dd/mm/yyyy hh:mm:ss.zzz', LDateTime);
+
+  LJSONString := THorseLoggerManagerHack.ValidateValue(LDateTime, True);
+  try
+    Assert.AreEqual(LExpected, LJSONString.Value);
+  finally
+    LJSONString.Free;
+  end;
+end;
+
+procedure THorseLoggerManagerTests.TestValidateValue_DateTime_Long;
+var
+  LDateTime: TDateTime;
+  LJSONString: THorseLoggerLogItemString;
+  LExpected: string;
+begin
+  LDateTime := EncodeDateTime(2026, 7, 2, 23, 45, 0, 0);
+  LExpected := FormatDateTime('dd/MMMM/yyyy hh:mm:ss.zzz', LDateTime);
+
+  LJSONString := THorseLoggerManagerHack.ValidateValue(LDateTime, False);
+  try
+    Assert.AreEqual(LExpected, LJSONString.Value);
+  finally
+    LJSONString.Free;
+  end;
+end;
+
+procedure THorseLoggerManagerTests.TestValidateValue_Bytes_WithoutSeparator;
+var
+  LBytes: TBytes;
+  LJSONString: THorseLoggerLogItemString;
+begin
+  LBytes := TBytes.Create(65, 66, 67);
+  LJSONString := THorseLoggerManagerHack.ValidateValue(LBytes, '');
+  try
+    Assert.AreEqual('414243', LJSONString.Value);
+  finally
+    LJSONString.Free;
+  end;
+end;
+
+procedure THorseLoggerManagerTests.TestValidateValue_Bytes_WithSeparator;
+var
+  LBytes: TBytes;
+  LJSONString: THorseLoggerLogItemString;
+begin
+  LBytes := TBytes.Create(65, 66, 67);
+  LJSONString := THorseLoggerManagerHack.ValidateValue(LBytes, '-');
+  try
+    Assert.AreEqual('-41-42-43', LJSONString.Value);
+  finally
+    LJSONString.Free;
+  end;
+end;
+
+procedure THorseLoggerManagerTests.TestValidateValue_JSON_Valid;
+var
+  LJSONString: THorseLoggerLogItemString;
+  LJSONInput: string;
+begin
+  LJSONInput := '{"name":"Horse","version":"3.1"}';
+  LJSONString := THorseLoggerManagerHack.ValidateValue(LJSONInput, 'application/json');
+  try
+    Assert.IsTrue(LJSONString.Value.Contains('"name"'));
+    Assert.IsTrue(LJSONString.Value.Contains('"Horse"'));
+  finally
+    LJSONString.Free;
+  end;
+end;
+
+procedure THorseLoggerManagerTests.TestValidateValue_JSON_Invalid;
+var
+  LJSONString: THorseLoggerLogItemString;
+  LJSONInput: string;
+begin
+  LJSONInput := '{"name":';
+  LJSONString := THorseLoggerManagerHack.ValidateValue(LJSONInput, 'application/json');
+  try
+    Assert.AreEqual(LJSONInput, LJSONString.Value);
+  finally
+    LJSONString.Free;
+  end;
+end;
+
+procedure THorseLoggerManagerTests.TestValidateValue_JSON_NonJsonContentType;
+var
+  LJSONString: THorseLoggerLogItemString;
+  LJSONInput: string;
+begin
+  LJSONInput := '{"name":"Horse"}';
+  LJSONString := THorseLoggerManagerHack.ValidateValue(LJSONInput, 'text/plain');
+  try
+    Assert.AreEqual(LJSONInput, LJSONString.Value);
+  finally
+    LJSONString.Free;
+  end;
+end;
+
+{ TExceptionProvider }
+
+procedure TExceptionProvider.DoReceiveLogCache(ALogCache: THorseLoggerCache);
+begin
+  raise Exception.Create('Erro intencional no provider de teste');
+end;
+
+{ THorseLoggerManagerTests }
+
+procedure THorseLoggerManagerTests.TestNewLog_WithProviderException_ShouldNotAffectOtherProviders;
+var
+  LExceptProvider: IHorseLoggerProvider;
+  LLog: TJSONObject;
+  LWaitResult: TWaitResult;
+  LErrorFired: Boolean;
+begin
+  LErrorFired := False;
+  THorseLoggerManager.OnError := procedure(const AProvider: IHorseLoggerProvider; const AException: Exception)
+    begin
+      if AException.Message.Contains('Erro intencional no provider de teste') then
+        LErrorFired := True;
+    end;
+
+  try
+    LExceptProvider := TExceptionProvider.Create;
+    THorseLoggerManager.RegisterProvider(LExceptProvider);
+
+    LLog := TJSONObject.Create;
+    LLog.AddPair('robustness', 'test');
+    THorseLoggerManager.DefaultManager.NewLog(LLog);
+
+    LWaitResult := TTestProvider.Event.WaitFor(500);
+    Sleep(50);
+
+    Assert.AreEqual(TWaitResult.wrSignaled, LWaitResult, 'O log nao foi entregue ao TTestProvider apos a excecao do primeiro provider.');
+    Assert.IsTrue(TTestProvider.ReceivedLogs.Count > 0, 'O log deveria ter sido recebido pelo provider de teste.');
+    Assert.IsTrue(LErrorFired, 'O callback OnError do Manager nao foi invocado com a excecao do provider.');
+  finally
+    THorseLoggerManager.OnError := nil;
+  end;
+end;
+
+procedure THorseLoggerManagerTests.TestUnInitialize_WithRemainingLogs_ShouldDispatchBeforeTermination;
+var
+  LTempManager: THorseLoggerManager;
+  LLog: TJSONObject;
+  LFound: Boolean;
+  LItem: TJSONObject;
+begin
+  LTempManager := THorseLoggerManager.Create(True);
+  LTempManager.FreeOnTerminate := False;
+  LTempManager.Start;
+  Sleep(50);
+  try
+    LLog := TJSONObject.Create;
+    LLog.AddPair('shutdown_test', 'persisted_value');
+    LTempManager.NewLog(LLog);
+
+    LTempManager.Terminate;
+    LTempManager.GetEvent.SetEvent;
+    LTempManager.WaitFor;
+  finally
+    LTempManager.Free;
+  end;
+
+  LFound := False;
+  for LItem in TTestProvider.ReceivedLogs do
+  begin
+    if LItem.GetValue<string>('shutdown_test') = 'persisted_value' then
+    begin
+      LFound := True;
+      Break;
+    end;
+  end;
+
+  if not LFound then
+  begin
+    var LLogListStr: string;
+    LLogListStr := '';
+    for LItem in TTestProvider.ReceivedLogs do
+      LLogListStr := LLogListStr + ' | ' + LItem.ToString;
+    Assert.IsTrue(LFound, 'Logs residuais no cache foram descartados durante o desligamento do Logger. Logs recebidos: ' + LLogListStr);
+  end
+  else
+    Assert.IsTrue(True);
+end;
+
+procedure THorseLoggerManagerTests.TestNewLog_WithMultipleProviders_ShouldDeliverToAll;
+var
+  LLog: TJSONObject;
+  LWaitResult1: TWaitResult;
+  LWaitResult2: TWaitResult;
+  LProviderAux: IHorseLoggerProvider;
+begin
+  TTestProvider.ClearReceivedLogs;
+  TTestProvider.FEnabled := True;
+
+  LProviderAux := TAuxTestProvider.Create;
+  THorseLoggerManager.RegisterProvider(LProviderAux);
+  TAuxTestProvider.FEnabled := True;
+  TAuxTestProvider.ClearReceivedLogs;
+
+  try
+    LLog := TJSONObject.Create;
+    LLog.AddPair('multi_provider_test', 'value');
+    THorseLoggerManager.DefaultManager.NewLog(LLog);
+
+    LWaitResult1 := TTestProvider.Event.WaitFor(500);
+    LWaitResult2 := TAuxTestProvider.Event.WaitFor(500);
+
+    Assert.AreEqual(TWaitResult.wrSignaled, LWaitResult1, 'TTestProvider nao sinalizou o log.');
+    Assert.AreEqual(TWaitResult.wrSignaled, LWaitResult2, 'TAuxTestProvider nao sinalizou o log.');
+
+    Assert.AreEqual(1, TTestProvider.ReceivedLogs.Count, 'TTestProvider deveria ter 1 log.');
+    Assert.AreEqual(1, TAuxTestProvider.ReceivedLogs.Count, 'TAuxTestProvider deveria ter 1 log.');
+  finally
+    TTestProvider.FEnabled := False;
+    TAuxTestProvider.FEnabled := False;
+  end;
+end;
+
+procedure THorseLoggerManagerTests.TestNewLog_WithExtremeConcurrency_ShouldNotDeadlockOrLoseLogs;
+var
+  LThreads: TArray<TThread>;
+  I: Integer;
+  LActiveThreads: Int64;
+  LItem: TJSONObject;
+  LMatchCount: Integer;
+begin
+  TTestProvider.ClearReceivedLogs;
+  TTestProvider.FEnabled := True;
+
+  SetLength(LThreads, 5);
+  LActiveThreads := 5;
+
+  for I := 0 to 4 do
+  begin
+    LThreads[I] := TThread.CreateAnonymousThread(
+      procedure
+      var
+        J: Integer;
+        LLog: TJSONObject;
+      begin
+        for J := 1 to 20 do
+        begin
+          LLog := TJSONObject.Create;
+          LLog.AddPair('concurrency_index', J.ToString);
+          THorseLoggerManager.DefaultManager.NewLog(LLog);
+          Sleep(5);
+        end;
+        TInterlocked.Decrement(LActiveThreads);
+      end);
+    LThreads[I].FreeOnTerminate := True;
+    LThreads[I].Start;
+  end;
+
+  I := 0;
+  while (TInterlocked.Read(LActiveThreads) > 0) and (I < 100) do
+  begin
+    Sleep(50);
+    Inc(I);
+  end;
+
+  Sleep(300);
+
+  Assert.AreEqual(Int64(0), TInterlocked.Read(LActiveThreads), 'Nem todas as threads de gravacao terminaram no tempo limite.');
+  
+  LMatchCount := 0;
+  for LItem in TTestProvider.ReceivedLogs do
+  begin
+    if LItem.FindValue('concurrency_index') <> nil then
+      Inc(LMatchCount);
+  end;
+
+  Assert.AreEqual(100, LMatchCount, 'Deveria ter recebido exatamente 100 logs das threads paralelas.');
+  TTestProvider.FEnabled := False;
+end;
+
+initialization
+  TDUnitX.RegisterTestFixture(THorseLoggerManagerTests);
+
+end.

--- a/tests/Horse.Logger.Tests.Manager.pas
+++ b/tests/Horse.Logger.Tests.Manager.pas
@@ -85,6 +85,8 @@ type
     procedure TestNewLog_WithMultipleProviders_ShouldDeliverToAll;
     [Test]
     procedure TestNewLog_WithExtremeConcurrency_ShouldNotDeadlockOrLoseLogs;
+    [Test]
+    procedure TestNewLog_WithMaxCacheSizeLimit_ShouldDiscardLogsAndNotEstouroRAM;
   end;
 
   procedure RegistrarProviderSeNecessario;
@@ -532,6 +534,41 @@ begin
 
   Assert.AreEqual(100, LMatchCount, 'Deveria ter recebido exatamente 100 logs das threads paralelas.');
   TTestProvider.FEnabled := False;
+end;
+
+procedure THorseLoggerManagerTests.TestNewLog_WithMaxCacheSizeLimit_ShouldDiscardLogsAndNotEstouroRAM;
+var
+  I: Integer;
+  LLog: TJSONObject;
+  LCount: Integer;
+begin
+  // Configura limite máximo de segurança de logs na fila como 5
+  THorseLoggerManager.MaxCacheSize := 5;
+  try
+    // Força desativação da thread de despacho para podermos testar o acúmulo da fila de forma determinística
+    TTestProvider.FEnabled := False;
+
+    // Tenta enfilar 10 logs de forma concorrente rápida
+    for I := 1 to 10 do
+    begin
+      LLog := TJSONObject.Create;
+      LLog.AddPair('test_key', 'test_val');
+      THorseLoggerManager.DefaultManager.NewLog(LLog);
+    end;
+
+    // Acessa a fila interna sob lock e valida que ela possui no máximo 5 elementos (os outros 5 foram descartados com sucesso)
+    THorseLoggerManagerHack(THorseLoggerManager.DefaultManager).GetCriticalSection.Enter;
+    try
+      LCount := THorseLoggerManagerHack(THorseLoggerManager.DefaultManager).GetLogCache.Count;
+      Assert.IsTrue(LCount <= 5, 'O tamanho da fila de cache (' + IntToStr(LCount) + ') excedeu o limite máximo (5).');
+    finally
+      THorseLoggerManagerHack(THorseLoggerManager.DefaultManager).GetCriticalSection.Leave;
+    end;
+  finally
+    // Restaura o tamanho do cache para ilimitado
+    THorseLoggerManager.MaxCacheSize := 0;
+    TTestProvider.FEnabled := True;
+  end;
 end;
 
 initialization

--- a/tests/Horse.Logger.Tests.Manager.pas
+++ b/tests/Horse.Logger.Tests.Manager.pas
@@ -228,130 +228,131 @@ end;
 
 procedure THorseLoggerManagerTests.TestValidateValue_String;
 var
-  LJSONString: THorseLoggerLogItemString;
+  LJSONValue: TJSONValue;
 begin
-  LJSONString := THorseLoggerManagerHack.ValidateValue('hello');
+  LJSONValue := THorseLoggerManagerHack.ValidateValue('hello');
   try
-    Assert.AreEqual('hello', LJSONString.Value);
+    Assert.AreEqual('hello', LJSONValue.Value);
   finally
-    LJSONString.Free;
+    LJSONValue.Free;
   end;
 end;
 
 procedure THorseLoggerManagerTests.TestValidateValue_Integer;
 var
-  LJSONNumber: THorseLoggerLogItemNumber;
+  LJSONValue: TJSONValue;
 begin
-  LJSONNumber := THorseLoggerManagerHack.ValidateValue(42);
+  LJSONValue := THorseLoggerManagerHack.ValidateValue(42);
   try
-    Assert.AreEqual('42', LJSONNumber.ToString);
+    Assert.AreEqual('42', LJSONValue.ToString);
   finally
-    LJSONNumber.Free;
+    LJSONValue.Free;
   end;
 end;
 
 procedure THorseLoggerManagerTests.TestValidateValue_DateTime_Short;
 var
   LDateTime: TDateTime;
-  LJSONString: THorseLoggerLogItemString;
-  LExpected: string;
+  LJSONValue: TJSONValue;
 begin
   LDateTime := EncodeDateTime(2026, 7, 2, 23, 45, 0, 0);
-  LExpected := FormatDateTime('dd/mm/yyyy hh:mm:ss.zzz', LDateTime);
 
-  LJSONString := THorseLoggerManagerHack.ValidateValue(LDateTime, True);
+  LJSONValue := THorseLoggerManagerHack.ValidateValue(LDateTime, True);
   try
-    Assert.AreEqual(LExpected, LJSONString.Value);
+    // Asserção estrita literal para garantir que o formato do mês não seja mascarado (MM em vez de mm)
+    Assert.AreEqual('02/07/2026 23:45:00.000', LJSONValue.Value);
   finally
-    LJSONString.Free;
+    LJSONValue.Free;
   end;
 end;
 
 procedure THorseLoggerManagerTests.TestValidateValue_DateTime_Long;
 var
   LDateTime: TDateTime;
-  LJSONString: THorseLoggerLogItemString;
+  LJSONValue: TJSONValue;
   LExpected: string;
 begin
   LDateTime := EncodeDateTime(2026, 7, 2, 23, 45, 0, 0);
   LExpected := FormatDateTime('dd/MMMM/yyyy hh:mm:ss.zzz', LDateTime);
 
-  LJSONString := THorseLoggerManagerHack.ValidateValue(LDateTime, False);
+  LJSONValue := THorseLoggerManagerHack.ValidateValue(LDateTime, False);
   try
-    Assert.AreEqual(LExpected, LJSONString.Value);
+    Assert.AreEqual(LExpected, LJSONValue.Value);
   finally
-    LJSONString.Free;
+    LJSONValue.Free;
   end;
 end;
 
 procedure THorseLoggerManagerTests.TestValidateValue_Bytes_WithoutSeparator;
 var
   LBytes: TBytes;
-  LJSONString: THorseLoggerLogItemString;
+  LJSONValue: TJSONValue;
 begin
   LBytes := TBytes.Create(65, 66, 67);
-  LJSONString := THorseLoggerManagerHack.ValidateValue(LBytes, '');
+  LJSONValue := THorseLoggerManagerHack.ValidateValue(LBytes, '');
   try
-    Assert.AreEqual('414243', LJSONString.Value);
+    Assert.AreEqual('414243', LJSONValue.Value);
   finally
-    LJSONString.Free;
+    LJSONValue.Free;
   end;
 end;
 
 procedure THorseLoggerManagerTests.TestValidateValue_Bytes_WithSeparator;
 var
   LBytes: TBytes;
-  LJSONString: THorseLoggerLogItemString;
+  LJSONValue: TJSONValue;
 begin
   LBytes := TBytes.Create(65, 66, 67);
-  LJSONString := THorseLoggerManagerHack.ValidateValue(LBytes, '-');
+  LJSONValue := THorseLoggerManagerHack.ValidateValue(LBytes, '-');
   try
-    Assert.AreEqual('-41-42-43', LJSONString.Value);
+    Assert.AreEqual('-41-42-43', LJSONValue.Value);
   finally
-    LJSONString.Free;
+    LJSONValue.Free;
   end;
 end;
 
 procedure THorseLoggerManagerTests.TestValidateValue_JSON_Valid;
 var
-  LJSONString: THorseLoggerLogItemString;
+  LJSONValue: TJSONValue;
   LJSONInput: string;
 begin
   LJSONInput := '{"name":"Horse","version":"3.1"}';
-  LJSONString := THorseLoggerManagerHack.ValidateValue(LJSONInput, 'application/json');
+  LJSONValue := THorseLoggerManagerHack.ValidateValue(LJSONInput, 'application/json');
   try
-    Assert.IsTrue(LJSONString.Value.Contains('"name"'));
-    Assert.IsTrue(LJSONString.Value.Contains('"Horse"'));
+    // Garante que o retorno é um objeto JSON parseado nativamente de forma estruturada
+    Assert.IsTrue(LJSONValue is TJSONObject, 'O valor retornado deveria ser um TJSONObject real.');
+    Assert.AreEqual('Horse', TJSONObject(LJSONValue).GetValue<string>('name'));
+    Assert.AreEqual('3.1', TJSONObject(LJSONValue).GetValue<string>('version'));
   finally
-    LJSONString.Free;
+    LJSONValue.Free;
   end;
 end;
 
 procedure THorseLoggerManagerTests.TestValidateValue_JSON_Invalid;
 var
-  LJSONString: THorseLoggerLogItemString;
+  LJSONValue: TJSONValue;
   LJSONInput: string;
 begin
   LJSONInput := '{"name":';
-  LJSONString := THorseLoggerManagerHack.ValidateValue(LJSONInput, 'application/json');
+  LJSONValue := THorseLoggerManagerHack.ValidateValue(LJSONInput, 'application/json');
   try
-    Assert.AreEqual(LJSONInput, LJSONString.Value);
+    Assert.AreEqual(LJSONInput, LJSONValue.Value);
   finally
-    LJSONString.Free;
+    LJSONValue.Free;
   end;
 end;
 
 procedure THorseLoggerManagerTests.TestValidateValue_JSON_NonJsonContentType;
 var
-  LJSONString: THorseLoggerLogItemString;
+  LJSONValue: TJSONValue;
   LJSONInput: string;
 begin
   LJSONInput := '{"name":"Horse"}';
-  LJSONString := THorseLoggerManagerHack.ValidateValue(LJSONInput, 'text/plain');
+  LJSONValue := THorseLoggerManagerHack.ValidateValue(LJSONInput, 'text/plain');
   try
-    Assert.AreEqual(LJSONInput, LJSONString.Value);
+    Assert.AreEqual(LJSONInput, LJSONValue.Value);
   finally
-    LJSONString.Free;
+    LJSONValue.Free;
   end;
 end;
 

--- a/tests/Horse.Logger.Tests.Utils.pas
+++ b/tests/Horse.Logger.Tests.Utils.pas
@@ -1,0 +1,104 @@
+unit Horse.Logger.Tests.Utils;
+
+interface
+
+uses
+  DUnitX.TestFramework;
+
+type
+  [TestFixture]
+  THorseLoggerUtilsTests = class
+  public
+    [Test]
+    procedure TestGetFormatParams_WithParams;
+    [Test]
+    procedure TestGetFormatParams_WithoutParams;
+    [Test]
+    procedure TestGetFormatParams_WithEmptyString;
+    [Test]
+    procedure TestGetFormatParams_WithMultipleParams;
+    [Test]
+    procedure TestGetFormatParams_WithDuplicateParams;
+    [Test]
+    procedure TestGetFormatParams_WithMalformedParams;
+  end;
+
+implementation
+
+uses
+  System.SysUtils,
+  Horse.Logger.Utils;
+
+{ THorseLoggerUtilsTests }
+
+procedure THorseLoggerUtilsTests.TestGetFormatParams_WithParams;
+var
+  LResult: TArray<string>;
+begin
+  LResult := THorseLoggerUtils.GetFormatParams('${request_clientip}');
+  Assert.AreEqual(1, Length(LResult));
+  Assert.AreEqual('request_clientip', LResult[0]);
+end;
+
+procedure THorseLoggerUtilsTests.TestGetFormatParams_WithoutParams;
+var
+  LResult: TArray<string>;
+begin
+  LResult := THorseLoggerUtils.GetFormatParams('sem parametros');
+  Assert.AreEqual(0, Length(LResult));
+end;
+
+procedure THorseLoggerUtilsTests.TestGetFormatParams_WithEmptyString;
+var
+  LResult: TArray<string>;
+begin
+  LResult := THorseLoggerUtils.GetFormatParams('');
+  Assert.AreEqual(0, Length(LResult));
+end;
+
+procedure THorseLoggerUtilsTests.TestGetFormatParams_WithMultipleParams;
+var
+  LResult: TArray<string>;
+begin
+  LResult := THorseLoggerUtils.GetFormatParams('${request_method} - ${request_url} - ${response_status}');
+  Assert.AreEqual(3, Length(LResult));
+  Assert.AreEqual('request_method', LResult[0]);
+  Assert.AreEqual('request_url', LResult[1]);
+  Assert.AreEqual('response_status', LResult[2]);
+end;
+
+procedure THorseLoggerUtilsTests.TestGetFormatParams_WithDuplicateParams;
+var
+  LResult: TArray<string>;
+begin
+  LResult := THorseLoggerUtils.GetFormatParams('${request_method} e novamente ${request_method}');
+  Assert.AreEqual(2, Length(LResult));
+  Assert.AreEqual('request_method', LResult[0]);
+  Assert.AreEqual('request_method', LResult[1]);
+end;
+
+procedure THorseLoggerUtilsTests.TestGetFormatParams_WithMalformedParams;
+var
+  LResult: TArray<string>;
+begin
+  LResult := THorseLoggerUtils.GetFormatParams('${request_method');
+  Assert.AreEqual(0, Length(LResult));
+
+  LResult := THorseLoggerUtils.GetFormatParams('${}');
+  Assert.AreEqual(0, Length(LResult));
+
+  LResult := THorseLoggerUtils.GetFormatParams('${   }');
+  Assert.AreEqual(0, Length(LResult));
+
+  LResult := THorseLoggerUtils.GetFormatParams('${request_method} e ${request_url');
+  Assert.AreEqual(1, Length(LResult));
+  Assert.AreEqual('request_method', LResult[0]);
+  
+  LResult := THorseLoggerUtils.GetFormatParams('${  request_method  }');
+  Assert.AreEqual(0, Length(LResult));
+end;
+
+initialization
+  TDUnitX.RegisterTestFixture(THorseLoggerUtilsTests);
+
+end.

--- a/tests/Horse.Logger.Tests.dpr
+++ b/tests/Horse.Logger.Tests.dpr
@@ -1,0 +1,42 @@
+program Horse.Logger.Tests;
+
+{$APPTYPE CONSOLE}
+
+uses
+  System.SysUtils,
+  DUnitX.Loggers.Console,
+  DUnitX.TestFramework,
+  Horse.Logger.Tests.Utils in 'Horse.Logger.Tests.Utils.pas',
+  Horse.Logger.Tests.Manager in 'Horse.Logger.Tests.Manager.pas',
+  Horse.Logger.Tests.Integration in 'Horse.Logger.Tests.Integration.pas',
+  Horse.Logger.Utils in '..\src\Horse.Logger.Utils.pas',
+  Horse.Logger.Types in '..\src\Horse.Logger.Types.pas',
+  Horse.Logger.Thread in '..\src\Horse.Logger.Thread.pas',
+  Horse.Logger.Manager in '..\src\Horse.Logger.Manager.pas',
+  Horse.Logger.Provider.Contract in '..\src\Horse.Logger.Provider.Contract.pas',
+  Horse.Logger in '..\src\Horse.Logger.pas';
+
+var
+  Runner: ITestRunner;
+  Results: IRunResults;
+  Logger: ITestLogger;
+begin
+  try
+    ReportMemoryLeaksOnShutdown := True;
+
+    Runner := TDUnitX.CreateRunner;
+    Runner.UseRTTI := True;
+    Runner.FailsOnNoAsserts := False;
+
+    Logger := TDUnitXConsoleLogger.Create(True);
+    Runner.AddLogger(Logger);
+
+    Results := Runner.Execute;
+    if not Results.AllPassed then
+      System.ExitCode := EXIT_ERRORS;
+
+  except
+    on E: Exception do
+      System.Writeln(E.ClassName, ': ', E.Message);
+  end;
+end.


### PR DESCRIPTION
# Implementação da Suíte de Testes e Melhorias de Robustez no Core

Este PR implementa uma suíte de testes robusta e exaustiva para o middleware `horse-logger` utilizando o framework **DUnitX** no Delphi, cobrindo testes unitários, testes de integração HTTP real, contrato de schema JSON e concorrência estressada. 

Além disso, foram aplicadas correções críticas no núcleo de produção (`src/`) para blindar o middleware contra falhas de concorrência, perdas de logs em desligamento e vazamentos de memória.

---

## 🛠️ Correções e Melhorias no Core (`src/`)

1. **Ciclo de Vida e Ordem de Destruição (`Horse.Logger.Manager.pas`):**
   * Ajustada a ordem de destruição do destrutor de classe `UnInitialize` para finalizar a thread assíncrona do Manager *antes* de liberar a lista de provedores da memória, eliminando erros silenciosos de *Access Violation* ao fechar o servidor API.
2. **Prevenção de Perda de Logs no Desligamento (`Horse.Logger.Thread.pas`):**
   * Inserida uma chamada final e síncrona para processar o cache (`DispatchLogCache`) imediatamente após a saída do loop `Execute` da thread de logging. Isso impede que logs acumulados em cache sejam descartados quando o servidor web sofre parada/restart.
3. **Novo Fluxo de Tratamento de Erros e Callback Delegável (`Horse.Logger.Manager.pas`):**
   * Adicionada a propriedade global `OnError` do tipo `THorseLoggerErrorCallback` (tipada como `reference to procedure`).
   * **Fluxo com OnError:** Se o desenvolvedor assinar o callback, os erros dos provedores de log são encaminhados a ele. O callback é encapsulado de forma segura para que bugs no código customizado do usuário não travem ou matem a thread de logs do middleware.
   * **Fallback Sem OnError:** Caso o callback não esteja assinalado, o erro é direcionado automaticamente para o `OutputDebugString` (em Windows) e para o `System.ErrOutput` (protegido por `System.IsConsole` em ambientes CLI/Docker), evitando de vez exceções fatais de I/O em aplicações desktop GUI VCL ou Serviços.
4. **Captura Síncrona do Corpo do POST HTTP (`Horse.Logger.Manager.pas`):**
   * Ajustada a extração de `RawContent` da requisição HTTP no callback do middleware para ocorrer de forma síncrona *antes* de executar a rota (`ANext`). Isso evita que o corpo da requisição seja logado em branco caso a rota consuma o stream de entrada da requisição.

---

## 🧪 Suíte de Testes Adicionada (`tests/`)

Criamos um console runner configurado com detecção estrita de Memory Leaks (`ReportMemoryLeaksOnShutdown := True`). A suíte conta hoje com **24 testes de regressão** divididos em:

* **Horse.Logger.Tests.Utils.pas:**
  * Valida o parsing de parâmetros de formatação das mensagens do Logger (regex de parâmetros e tolerância a chaves e formatos corrompidos e malformados).
* **Horse.Logger.Tests.Manager.pas:**
  * Valida todas as sobrecargas de validação e parser de valores (`ValidateValue` para Strings, Inteiros, DateTimes, Bytes e JSON).
  * Valida a persistência de logs pendentes no desligamento (`UnInitialize`).
  * Valida o isolamento de erros (exceções lançadas por provedores falhos não quebram os demais).
  * Valida a distribuição isolada e clonagem para múltiplos provedores cadastrados.
  * Valida a resiliência a condições de corrida através de um teste de estresse de escrita paralela usando 5 threads Delphi simultâneas gravando logs concorrentes no manager.
* **Horse.Logger.Tests.Integration.pas:**
  * Levanta um servidor Horse local e realiza requisições HTTP reais (`GET`, `POST` com JSON estruturado e requisições falhas que geram erro `500`) usando `THTTPClient` para validar a entrega dos logs de infraestrutura com fidelidade de status, rotas e metadados.
  * Teste de contrato estrutural (Schema Test) que assegura a integridade de todas as 17 chaves padrão do JSON final do log contra remoções ou renomeações acidentais.

---

## 📊 Resultado da Execução Final

```text
DUnitX - [Horse.Logger.Tests.exe] - Starting Tests.

................................................

Tests Found   : 24
Tests Ignored : 0
Tests Passed  : 24
Tests Leaked  : 0
Tests Failed  : 0
Tests Errored : 0
