### PR TITLE
fix: resolve high CPU usage on Delphi/Linux (#23)

### DIFF
--- a/src/Horse.Logger.Thread.pas
+++ b/src/Horse.Logger.Thread.pas
@@ -53,7 +53,11 @@ implementation
 procedure THorseLoggerThread.AfterConstruction;
 begin
   inherited;
-  FEvent := TEvent.Create{$IFDEF FPC}(nil, False, True, TGuid.NewGuid.ToString(True)){$ENDIF};
+{$IFDEF FPC}
+  FEvent := TEvent.Create(nil, False, False, TGuid.NewGuid.ToString(True));
+{$ELSE}
+  FEvent := TEvent.Create(nil, False, False, '');
+{$ENDIF}
   FCriticalSection := TCriticalSection.Create;
   FLogCache := THorseLoggerCache.Create;
   FMaxCacheSize := 0;

--- a/tests/Horse.Logger.Tests.Manager.pas
+++ b/tests/Horse.Logger.Tests.Manager.pas
@@ -5,7 +5,7 @@ interface
 uses
   DUnitX.TestFramework, System.SysUtils, System.JSON, System.SyncObjs, System.DateUtils,
   System.Classes,
-  Horse.Logger.Types, Horse.Logger.Provider.Contract, Horse.Logger.Manager;
+  Horse.Logger.Types, Horse.Logger.Provider.Contract, Horse.Logger.Manager, Horse.Logger.Thread;
 
 type
   TTestProvider = class(TInterfacedObject, IHorseLoggerProvider)
@@ -87,6 +87,8 @@ type
     procedure TestNewLog_WithExtremeConcurrency_ShouldNotDeadlockOrLoseLogs;
     [Test]
     procedure TestNewLog_WithMaxCacheSizeLimit_ShouldDiscardLogsAndNotEstouroRAM;
+    [Test]
+    procedure TestLoggerThreadEvent_ShouldBeAutoReset;
   end;
 
   procedure RegistrarProviderSeNecessario;
@@ -568,6 +570,25 @@ begin
     // Restaura o tamanho do cache para ilimitado
     THorseLoggerManager.MaxCacheSize := 0;
     TTestProvider.FEnabled := True;
+  end;
+end;
+
+procedure THorseLoggerManagerTests.TestLoggerThreadEvent_ShouldBeAutoReset;
+var
+  LThread: THorseLoggerThread;
+  LWaitResult1: TWaitResult;
+  LWaitResult2: TWaitResult;
+begin
+  LThread := THorseLoggerThread.Create(True);
+  try
+    LThread.GetEvent.ResetEvent;
+    LThread.GetEvent.SetEvent;
+    LWaitResult1 := LThread.GetEvent.WaitFor(100);
+    Assert.AreEqual(TWaitResult.wrSignaled, LWaitResult1, 'O primeiro WaitFor deveria retornar wrSignaled apos o SetEvent.');
+    LWaitResult2 := LThread.GetEvent.WaitFor(10);
+    Assert.AreEqual(TWaitResult.wrTimeout, LWaitResult2, 'O segundo WaitFor consecutivo deveria dar timeout (Auto-Reset), mas retornou wrSignaled.');
+  finally
+    LThread.Free;
   end;
 end;
 


### PR DESCRIPTION
# Descrição
Este Pull Request corrige o problema de consumo de 100% de CPU por thread de logging no Delphi/Linux (e Windows) relatado na Issue #23.

## Causa do Problema
No commit `5857c1c`, a chamada a `GetEvent.ResetEvent` foi removida do loop de execução da thread. Como o `TEvent` era criado por padrão como **Manual-Reset** no Delphi (ao contrário do Lazarus/FPC onde era criado como Auto-Reset), sem o `ResetEvent` o sinal permanecia eternamente ativo. Consequentemente, o método `WaitFor(INFINITE)` retornava de forma síncrona imediata a cada iteração, colocando a thread de log em *busy wait* infinito.

## Solução Adotada
Ajustamos a instanciação do `TEvent` em `THorseLoggerThread.AfterConstruction` para ser explicitamente **Auto-Reset** tanto no Delphi quanto no FPC.
- Com o **Auto-Reset**, o sinal do evento é consumido e limpo atomicamente no retorno de `WaitFor`.
- Isso evita a necessidade de um `ResetEvent` manual no loop da thread, eliminando de forma definitiva qualquer risco de *race condition* (sinal limpo incorretamente por novos logs paralelos).

## Testes Realizados
- Criado o teste unitário de regressão `TestLoggerThreadEvent_ShouldBeAutoReset` que valida o comportamento Auto-Reset do evento.
- Validação no **Delphi 12 (Win32)**: Suíte com todos os 26 testes unitários executada com 100% de sucesso.
- Validação de compilação no **Free Pascal (FPC 3.2.2)**.
- Validação de compilação no compilador oficial do **Delphi para Linux (dcclinux64.exe)**.
